### PR TITLE
Small performance boost in the memory backend

### DIFF
--- a/backend/memory/memory.go
+++ b/backend/memory/memory.go
@@ -71,7 +71,7 @@ func (r *Backend) Open(options url.Values) {
 }
 
 func (r Backend) GetTenants() []backend.Tenant {
-	res := make([]backend.Tenant, 0)
+	res := make([]backend.Tenant, 0, len(r.tenant))
 
 	// return a list of tenants
 	for key := range r.tenant {


### PR DESCRIPTION
Providing the capacity of the backend.Tenant slice does less allocations than without.

Reducing that number can make a function run faster than usually.

Running benchmark tests showed >2x improvement depending on the number of items.
