### PR TITLE
Adding support for alert definition from configuration file.

### DIFF
--- a/alerts/alert.go
+++ b/alerts/alert.go
@@ -13,25 +13,25 @@ const (
 type RangeIntervalType int
 
 type Range struct {
-	from float64
-	to   float64
-	t    RangeIntervalType
+	From float64		   `mapstructure:"from"`
+	To   float64           `mapstructure:"to"`
+	Type RangeIntervalType `mapstructure:"type"`
 }
 
 type Alert struct {
-	id      string
-	r       Range
-	state   bool
+	Id      string         `mapstructure:"id"`
+	Range   Range		   `mapstructure:"range"`
+	State   bool		   `mapstructure:"state"`
 }
 
 type AlertList struct {
-	tenant  backend.Tenant
-	list []Alert `mapstructure:"alert_list`
+	Tenant  backend.Tenant `mapstructure:"tenant"`
+	List []Alert 		   `mapstructure:"alert_list"`
 }
 
 type Alerts struct{
-	Backend backend.Backend
-	Verbose bool
-	AlertLists []AlertList `mapstructure:"alerts`
+	Backend backend.Backend `mapstrcuture: "backend"`
+	Verbose bool			`mapstrcuture: "verbose"`
+	AlertLists []AlertList  `mapstructure: "alerts"`
 }
 

--- a/alerts/utils.go
+++ b/alerts/utils.go
@@ -2,21 +2,21 @@ package alerts
 
 func (alert *Alert) checkOutOfRange(value float64) bool {
 	var res bool
-	switch alert.r.t {
+	switch alert.Range.Type {
 	case BETWEEN:
-		if (value < alert.r.from || value > alert.r.to) {
+		if (value < alert.Range.From || value > alert.Range.To) {
 			res = true
 		} else {
 			res = false
 		}
 	case LOWER_THAN:
-		if (value > alert.r.to) {
+		if (value > alert.Range.To) {
 			res = true
 		} else {
 			res =  false
 		}
 	case HIGHER_THAN:
-		if (value < alert.r.from) {
+		if (value < alert.Range.From) {
 			res = true
 		} else {
 			res = false
@@ -26,13 +26,9 @@ func (alert *Alert) checkOutOfRange(value float64) bool {
 }
 
 func (alert *Alert) setStatus(status bool){
-	alert.state = status
+	alert.State = status
 }
 
-func (alert *Alert) getAlertId() string {
-	return alert.id
-}
-
-func (Alerts Alerts) Open(alertList []Alert) {}
+func (Alerts Alerts) Open() {}
 
 

--- a/api/server.go
+++ b/api/server.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/spf13/viper"
 
+	"github.com/MohawkTSDB/mohawk/alerts"
 	"github.com/MohawkTSDB/mohawk/backend"
 	"github.com/MohawkTSDB/mohawk/backend/example"
 	"github.com/MohawkTSDB/mohawk/backend/memory"
@@ -91,6 +92,18 @@ func Serve() error {
 
 	// set global variables
 	BackendName = db.Name()
+
+	if viper.ConfigFileUsed() != "" && viper.Get("alerts") != "" {
+		// create alerts object.
+		a := []alerts.AlertList{}
+		viper.UnmarshalKey("alerts", &a)
+		alertsObj := alerts.Alerts{
+			Backend:    db,
+			Verbose:    verbose,
+			AlertLists: a,
+		}
+		alertsObj.Open()
+	}
 
 	// h common variables to be used for the backend Handler functions
 	// backend the backend to use for metrics source


### PR DESCRIPTION
Adding support for alert configuration through config yaml file, example: 
```
backend: "memory"
port: 8085
alerts:
- tenant: "_system"
  alert_list:
  - id: "free_memory"
    range:
      from: 2000
      to: 2100
      type: "BETWEEN"
    state: "false"
- tenant: "ops"
  alert_list:
  - id: "cpu_usage"
    range:
      from: 1.7
      to:
      type: "HIGHER_THAN"
    state: "false"

```