### PR TITLE
Add unit tests to middleware

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,6 @@ addons:
     packages:
     - bats
     - bc
-script: make test
+script:
+  - make test-unit
+  - make test

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,10 @@ clean:
 test: clean vendor all install
 	bats test/mohawk.bats
 
+.PHONY: test-unit
+test-unit: clean vendor
+	@go test $(shell go list ./... | grep -v vendor)
+
 .PHONY: secret
 secret:
 	openssl ecparam -genkey -name secp384r1 -out server.key

--- a/middleware/authorization_test.go
+++ b/middleware/authorization_test.go
@@ -1,0 +1,62 @@
+package middleware
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestAuthServeHTTP(t *testing.T) {
+	OkBody := "DONE"
+	a := Authorization{
+		UseToken:        true,
+		PublicPathRegex: "^/bla/boy",
+		Token:           "ninja",
+		next: HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintln(w, OkBody)
+		}),
+	}
+
+	testcases := []struct {
+		path    string
+		token   string
+		code    int
+		content string
+	}{
+		{"/bla/boy/1", "", http.StatusOK, OkBody},
+		{"/hello/world", "", http.StatusUnauthorized, "Unauthorized - 401"},
+		{"/hello/world", a.Token, http.StatusOK, OkBody},
+		{"/bla/boy/2", a.Token, http.StatusOK, OkBody},
+	}
+
+	var (
+		err  error
+		req  *http.Request
+		body []byte
+	)
+
+	for _, tc := range testcases {
+		if req, err = http.NewRequest(http.MethodGet, tc.path, nil); err != nil {
+			t.Error(err)
+		}
+		if tc.token != "" {
+			req.Header.Set("Authorization", "Bearer "+tc.token)
+		}
+		res := httptest.NewRecorder()
+		a.ServeHTTP(res, req)
+
+		if body, err = ioutil.ReadAll(res.Body); err != nil {
+			t.Error(err)
+		}
+		if !strings.Contains(string(body), tc.content) {
+			t.Errorf("expected body '%s' to contain '%s' path %s", string(body), tc.content, tc.path)
+		}
+		if res.Code != tc.code {
+			t.Errorf("expected status code to be %d but got %d path %s", tc.code, res.Code, tc.path)
+		}
+	}
+
+}

--- a/middleware/badrequest_test.go
+++ b/middleware/badrequest_test.go
@@ -1,0 +1,35 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestBadRequestServeHTTP(t *testing.T) {
+	a := BadRequest{}
+	var (
+		req *http.Request
+		err error
+	)
+
+	testcases := []struct {
+		method string
+		status int
+	}{
+		{http.MethodGet, http.StatusNotFound},
+		{http.MethodHead, http.StatusNotFound},
+		{http.MethodOptions, http.StatusOK},
+	}
+	for _, tc := range testcases {
+		if req, err = http.NewRequest(tc.method, "/", nil); err != nil {
+			t.Error(err)
+		}
+		res := httptest.NewRecorder()
+		a.ServeHTTP(res, req)
+
+		if res.Code != tc.status {
+			t.Errorf("expected status code to be %d but got %d", tc.status, res.Code)
+		}
+	}
+}

--- a/middleware/gzipper_test.go
+++ b/middleware/gzipper_test.go
@@ -1,0 +1,91 @@
+package middleware
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"compress/gzip"
+)
+
+func TestGzipServeHTTP(t *testing.T) {
+	a := GZipper{
+		next: HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Body == nil {
+				t.Error("body was not supposed to be nil")
+			}
+			body, err := ioutil.ReadAll(r.Body)
+			if err != nil {
+				t.Error(err)
+			}
+			fmt.Fprintf(w, string(body))
+		}),
+	}
+	var (
+		req  *http.Request
+		err  error
+		body []byte
+	)
+
+	testcases := []struct {
+		useGzip  bool
+		header   map[string]string
+		bodyStr  string
+		expected string
+		toGunzip bool
+		toGzip   bool
+	}{
+		{true, map[string]string{}, "none", "none", false, false},
+		{false, map[string]string{}, "none", "none", false, false},
+		{true, map[string]string{"Accept-Encoding": "gzip"}, "bla", "bla", true, false},
+		{true, map[string]string{"Content-Encoding": "gzip"}, "gzbla", "gzbla", false, true},
+		{true, map[string]string{"Content-Encoding": "gzip", "Accept-Encoding": "gzip"}, "gzbla", "gzbla", true, true},
+	}
+	var reader io.Reader
+	for _, tc := range testcases {
+		a.UseGzip = tc.useGzip
+		reader = bytes.NewBufferString(tc.bodyStr)
+		if tc.toGzip {
+			buff := bytes.NewBuffer(nil)
+			gWriter := gzip.NewWriter(buff)
+			gWriter.Write([]byte(tc.bodyStr))
+			if err := gWriter.Flush(); err != nil {
+				t.Error(err)
+			}
+			if err := gWriter.Close(); err != nil {
+				t.Error(err)
+			}
+			reader = buff
+		}
+		if req, err = http.NewRequest(http.MethodGet, "/", reader); err != nil {
+			t.Error(err)
+		}
+		if len(tc.header) > 0 {
+			for k, v := range tc.header {
+				req.Header.Set(k, v)
+			}
+		}
+		res := httptest.NewRecorder()
+		a.ServeHTTP(res, req)
+
+		var bodyReader io.Reader
+		bodyReader = res.Body
+		if tc.toGunzip {
+			bodyReader, err = gzip.NewReader(bodyReader)
+			if err != nil {
+				t.Error(err)
+			}
+		}
+		if body, err = ioutil.ReadAll(bodyReader); err != nil {
+			t.Error(err)
+		}
+
+		if string(body) != tc.expected {
+			t.Errorf("expected response body to be '%s' but got '%s'", tc.expected, string(body))
+		}
+	}
+}

--- a/middleware/headers_test.go
+++ b/middleware/headers_test.go
@@ -1,0 +1,34 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+func TestHeadersServeHTTP(t *testing.T) {
+	a := Headers{
+		next: HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		}),
+	}
+	var (
+		req *http.Request
+		err error
+	)
+	if req, err = http.NewRequest(http.MethodGet, "/something", nil); err != nil {
+		t.Error(err)
+	}
+	res := httptest.NewRecorder()
+	a.ServeHTTP(res, req)
+
+	expected := http.Header{}
+	expected.Set("Content-Type", "application/json")
+	expected.Set("Access-Control-Allow-Origin", "*")
+	expected.Set("Access-Control-Allow-Headers", "authorization,content-type,hawkular-tenant")
+	expected.Set("Access-Control-Allow-Methods", "GET, POST, DELETE, PUT")
+
+	if !reflect.DeepEqual(expected, res.Header()) {
+		t.Errorf("expected header to be equal to '%v' but got '%v'", expected, res.Header())
+	}
+}

--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -21,9 +21,12 @@ import (
 	"net/http"
 )
 
+type logFunc func(format string, v ...interface{})
+
 // Logger middleware that will log http requests
 type Logger struct {
 	Verbose bool
+	logFunc logFunc
 	next    http.Handler
 }
 
@@ -34,7 +37,10 @@ func (l *Logger) SetNext(h http.Handler) {
 
 // ServeHTTP http serve func
 func (l Logger) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	log.Printf("%s Accept-Encoding: %s, %4s %s", r.RemoteAddr, r.Header.Get("Accept-Encoding"), r.Method, r.URL)
+	if l.logFunc == nil {
+		l.logFunc = log.Printf
+	}
+	l.logFunc("%s Accept-Encoding: %s, %4s %s", r.RemoteAddr, r.Header.Get("Accept-Encoding"), r.Method, r.URL)
 
 	l.next.ServeHTTP(w, r)
 }

--- a/middleware/logger_test.go
+++ b/middleware/logger_test.go
@@ -1,0 +1,47 @@
+package middleware
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestLoggerServeHTTP(t *testing.T) {
+	a := Logger{
+		next: HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintf(w, "OK")
+		}),
+	}
+	var (
+		req *http.Request
+		err error
+	)
+
+	buff := bytes.NewBufferString("")
+	testcases := []struct {
+		logFunc logFunc
+	}{
+		{nil},
+		{logFunc(func(format string, v ...interface{}) {
+			fmt.Fprintf(buff, format, v...)
+		})},
+	}
+	for _, tc := range testcases {
+		buff.Reset()
+		a.logFunc = tc.logFunc
+		if req, err = http.NewRequest(http.MethodGet, "/", nil); err != nil {
+			t.Error(err)
+		}
+		res := httptest.NewRecorder()
+		a.ServeHTTP(res, req)
+
+		if tc.logFunc != nil {
+			expected := fmt.Sprintf("%s Accept-Encoding: %s, %4s %s", req.RemoteAddr, req.Header.Get("Accept-Encoding"), req.Method, req.URL)
+			if buff.String() != expected {
+				t.Errorf("expected output to be '%s' but got '%s'", expected, buff)
+			}
+		}
+	}
+}

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -20,6 +20,14 @@ import (
 	"net/http"
 )
 
+// HandlerFunc implements ServeHTTP and it's actually a function that its
+// signature is similar to http.HandlerFunc
+type HandlerFunc func(w http.ResponseWriter, r *http.Request)
+
+func (hf HandlerFunc) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	hf(w, r)
+}
+
 type MiddleWare interface {
 	SetNext(http.Handler)
 	ServeHTTP(http.ResponseWriter, *http.Request)

--- a/middleware/static.go
+++ b/middleware/static.go
@@ -24,7 +24,7 @@ import (
 	"path/filepath"
 )
 
-// Logger middleware that will log http requests
+// Static middleware serves static files
 type Static struct {
 	Verbose   bool
 	MediaPath string

--- a/middleware/static_test.go
+++ b/middleware/static_test.go
@@ -1,0 +1,48 @@
+package middleware
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestStaticServeHTTP(t *testing.T) {
+	a := Static{
+		MediaPath: "./tests",
+		next: HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintf(w, "OK")
+		}),
+	}
+	var (
+		req  *http.Request
+		err  error
+		body []byte
+	)
+
+	testcases := []struct {
+		reqURL  string
+		expBody string
+	}{
+		{"/", "<div>Hello world</div>"},
+		{"/index.html", "<div>Hello world</div>"},
+		{"/inner", "<div>inner hello</div>"},
+		{"/index1.html", "OK"},
+	}
+	for _, tc := range testcases {
+		if req, err = http.NewRequest(http.MethodGet, tc.reqURL, nil); err != nil {
+			t.Error(err)
+		}
+		res := httptest.NewRecorder()
+		a.ServeHTTP(res, req)
+
+		if body, err = ioutil.ReadAll(res.Body); err != nil {
+			t.Error(err)
+		}
+
+		if string(body) != tc.expBody {
+			t.Errorf("expected response body to be equal to '%s' but got '%s'", tc.expBody, string(body))
+		}
+	}
+}

--- a/middleware/tests/index.html
+++ b/middleware/tests/index.html
@@ -1,0 +1,1 @@
+<div>Hello world</div>

--- a/middleware/tests/inner/index.html
+++ b/middleware/tests/inner/index.html
@@ -1,0 +1,1 @@
+<div>inner hello</div>


### PR DESCRIPTION
The `middlewares` are missing unit tests to verify the logic in the `ServeHTTP` functions.
This patch gives a good starting point to test this.

This is related to #23 

The code coverage increased from 0% to 81.5%.
I haven't tested `Append` and `SetNext` as I am going to remove them in the future.

To see what exactly the tests cover, run the following:
```
$ cd middleware
$ go test -v -coverprofile=c.out
$ go tool cover -html=c.out
```

Your browser will display what lines were covered, not-covered and not-tracked.
You can jump to different code files by choosing the filename in the drop-down menu on the top left.

Thanks.
