### PR TITLE
Refactor middlewares

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,8 @@ test: clean vendor all install
 	bats test/mohawk.bats
 
 .PHONY: test-unit
-test-unit: clean vendor
+test-unit: vendor
+	@echo "running unit tests"
 	@go test $(shell go list ./... | grep -v vendor)
 
 .PHONY: secret
@@ -43,4 +44,4 @@ install: fmt mohawk
 .PHONY: vendor
 vendor:
 	[ -d ${GOPATH}/src/github.com/LK4D4/vndr ] || go get -u -v github.com/LK4D4/vndr
-	${GOPATH}/bin/vndr
+	[ -d ${GOPATH}/src/github.com/MohawkTSDB/mohawk/vendor ] || ${GOPATH}/bin/vndr

--- a/middleware/authorization_test.go
+++ b/middleware/authorization_test.go
@@ -10,16 +10,11 @@ import (
 )
 
 func TestAuthServeHTTP(t *testing.T) {
+	token := "mytoken"
 	OkBody := "DONE"
-	a := Authorization{
-		UseToken:        true,
-		PublicPathRegex: "^/bla/boy",
-		Token:           "ninja",
-		next: HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			fmt.Fprintln(w, OkBody)
-		}),
-	}
-
+	a := AuthDecorator(token, "^/bla/boy")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, OkBody)
+	}))
 	testcases := []struct {
 		path    string
 		token   string
@@ -28,8 +23,8 @@ func TestAuthServeHTTP(t *testing.T) {
 	}{
 		{"/bla/boy/1", "", http.StatusOK, OkBody},
 		{"/hello/world", "", http.StatusUnauthorized, "Unauthorized - 401"},
-		{"/hello/world", a.Token, http.StatusOK, OkBody},
-		{"/bla/boy/2", a.Token, http.StatusOK, OkBody},
+		{"/hello/world", token, http.StatusOK, OkBody},
+		{"/bla/boy/2", token, http.StatusOK, OkBody},
 	}
 
 	var (

--- a/middleware/badrequest.go
+++ b/middleware/badrequest.go
@@ -18,30 +18,20 @@ package middleware
 
 import (
 	"fmt"
-	"log"
 	"net/http"
 )
 
-// BadRequest will be called if no route found
-type BadRequest struct {
-	Verbose bool
-}
-
-// SetNext set next http serve func
-func (b *BadRequest) SetNext(_h http.Handler) {
-}
-
-// ServeHTTP http serve func
-func (b BadRequest) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	// we return 200 for any OPTIONS request
-	if r.Method == "OPTIONS" {
-		w.WriteHeader(200)
-		return
-	}
-
-	log.Printf("Page not found - 404:\n")
-	log.Printf("%s Accept-Encoding: %s, %4s %s", r.RemoteAddr, r.Header.Get("Accept-Encoding"), r.Method, r.URL)
-
-	w.WriteHeader(404)
-	fmt.Fprintf(w, "Page not found - 404\n")
+func BadRequestDecorator(logFunc func(string, ...interface{})) Decorator {
+	return Decorator(func(h http.HandlerFunc) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			// we return 200 for any OPTIONS request
+			if r.Method == "OPTIONS" {
+				w.WriteHeader(200)
+				return
+			}
+			logFunc("Page not found - 404:\n")
+			w.WriteHeader(404)
+			fmt.Fprintf(w, "Page not found - 404\n")
+		}
+	})
 }

--- a/middleware/badrequest_test.go
+++ b/middleware/badrequest_test.go
@@ -1,13 +1,14 @@
 package middleware
 
 import (
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 )
 
 func TestBadRequestServeHTTP(t *testing.T) {
-	a := BadRequest{}
+	a := BadRequestDecorator(log.Printf)(func(w http.ResponseWriter, r *http.Request) {})
 	var (
 		req *http.Request
 		err error

--- a/middleware/gzipper_test.go
+++ b/middleware/gzipper_test.go
@@ -13,18 +13,16 @@ import (
 )
 
 func TestGzipServeHTTP(t *testing.T) {
-	a := GZipper{
-		next: HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.Body == nil {
-				t.Error("body was not supposed to be nil")
-			}
-			body, err := ioutil.ReadAll(r.Body)
-			if err != nil {
-				t.Error(err)
-			}
-			fmt.Fprintf(w, string(body))
-		}),
-	}
+	a := GzipDecodeDecorator()(GzipEncodeDecorator()(func(w http.ResponseWriter, r *http.Request) {
+		if r.Body == nil {
+			t.Error("body was not supposed to be nil")
+		}
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			t.Error(err)
+		}
+		fmt.Fprintf(w, string(body))
+	}))
 	var (
 		req  *http.Request
 		err  error
@@ -47,7 +45,7 @@ func TestGzipServeHTTP(t *testing.T) {
 	}
 	var reader io.Reader
 	for _, tc := range testcases {
-		a.UseGzip = tc.useGzip
+		//a.UseGzip = tc.useGzip
 		reader = bytes.NewBufferString(tc.bodyStr)
 		if tc.toGzip {
 			buff := bytes.NewBuffer(nil)

--- a/middleware/headers_test.go
+++ b/middleware/headers_test.go
@@ -1,17 +1,17 @@
 package middleware
 
 import (
+	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"testing"
 )
 
-func TestHeadersServeHTTP(t *testing.T) {
-	a := Headers{
-		next: HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		}),
-	}
+func TestDefaultHeadersServeHTTP(t *testing.T) {
+	a := DefaultHeadersDecorator()(func(w http.ResponseWriter, r *http.Request) {
+	})
 	var (
 		req *http.Request
 		err error
@@ -31,4 +31,38 @@ func TestHeadersServeHTTP(t *testing.T) {
 	if !reflect.DeepEqual(expected, res.Header()) {
 		t.Errorf("expected header to be equal to '%v' but got '%v'", expected, res.Header())
 	}
+}
+
+func TestHeadersServeHTTP(t *testing.T) {
+	okBody := "OK"
+	a := HeadersDecorator(map[string]string{
+		"User-Agent": "blabla",
+	})(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, okBody)
+	})
+	var (
+		req *http.Request
+		err error
+	)
+	if req, err = http.NewRequest(http.MethodGet, "/something", nil); err != nil {
+		t.Error(err)
+	}
+	res := httptest.NewRecorder()
+	a.ServeHTTP(res, req)
+
+	expected := http.Header{}
+	expected.Set("User-Agent", "blabla")
+	expected.Set("Content-Type", "text/plain; charset=utf-8") // this header is added once we are writing something to the body
+
+	if !reflect.DeepEqual(expected, res.Header()) {
+		t.Errorf("expected header to be equal to '%v' but got '%v'", expected, res.Header())
+	}
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		t.Error(err)
+	}
+	if string(body) != "OK" {
+		t.Errorf("expected body '%s' to contain '%s'", string(body), "OK")
+	}
+
 }

--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -17,30 +17,14 @@
 package middleware
 
 import (
-	"log"
 	"net/http"
 )
 
-type logFunc func(format string, v ...interface{})
-
-// Logger middleware that will log http requests
-type Logger struct {
-	Verbose bool
-	logFunc logFunc
-	next    http.Handler
-}
-
-// SetNext set next http serve func
-func (l *Logger) SetNext(h http.Handler) {
-	l.next = h
-}
-
-// ServeHTTP http serve func
-func (l Logger) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	if l.logFunc == nil {
-		l.logFunc = log.Printf
-	}
-	l.logFunc("%s Accept-Encoding: %s, %4s %s", r.RemoteAddr, r.Header.Get("Accept-Encoding"), r.Method, r.URL)
-
-	l.next.ServeHTTP(w, r)
+func LoggingDecorator(logFunc func(format string, v ...interface{})) Decorator {
+	return Decorator(func(h http.HandlerFunc) http.HandlerFunc {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			logFunc("%s Accept-Encoding: %s, %4s %s", r.RemoteAddr, r.Header.Get("Accept-Encoding"), r.Method, r.URL)
+			h(w, r)
+		})
+	})
 }

--- a/middleware/logger_test.go
+++ b/middleware/logger_test.go
@@ -9,11 +9,6 @@ import (
 )
 
 func TestLoggerServeHTTP(t *testing.T) {
-	a := Logger{
-		next: HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			fmt.Fprintf(w, "OK")
-		}),
-	}
 	var (
 		req *http.Request
 		err error
@@ -21,27 +16,26 @@ func TestLoggerServeHTTP(t *testing.T) {
 
 	buff := bytes.NewBufferString("")
 	testcases := []struct {
-		logFunc logFunc
+		logFunc func(string, ...interface{})
 	}{
-		{nil},
-		{logFunc(func(format string, v ...interface{}) {
+		{func(format string, v ...interface{}) {
 			fmt.Fprintf(buff, format, v...)
-		})},
+		}},
 	}
 	for _, tc := range testcases {
 		buff.Reset()
-		a.logFunc = tc.logFunc
+		a := LoggingDecorator(tc.logFunc)(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintf(w, "OK")
+		})
 		if req, err = http.NewRequest(http.MethodGet, "/", nil); err != nil {
 			t.Error(err)
 		}
 		res := httptest.NewRecorder()
 		a.ServeHTTP(res, req)
 
-		if tc.logFunc != nil {
-			expected := fmt.Sprintf("%s Accept-Encoding: %s, %4s %s", req.RemoteAddr, req.Header.Get("Accept-Encoding"), req.Method, req.URL)
-			if buff.String() != expected {
-				t.Errorf("expected output to be '%s' but got '%s'", expected, buff)
-			}
+		expected := fmt.Sprintf("%s Accept-Encoding: %s, %4s %s", req.RemoteAddr, req.Header.Get("Accept-Encoding"), req.Method, req.URL)
+		if buff.String() != expected {
+			t.Errorf("expected output to be '%s' but got '%s'", expected, buff)
 		}
 	}
 }

--- a/middleware/middleware_test.go
+++ b/middleware/middleware_test.go
@@ -1,0 +1,19 @@
+package middleware
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/MohawkTSDB/mohawk/router"
+)
+
+func TestAppendMiddleware(t *testing.T) {
+	myRoute := router.Router{
+		Prefix: "/hawkular/bla/",
+	}
+	myRoute.Add("GET", ":id/info", func(w http.ResponseWriter, r *http.Request, argv map[string]string) {
+		fmt.Fprintf(w, "got data")
+	})
+
+}

--- a/middleware/static_test.go
+++ b/middleware/static_test.go
@@ -9,12 +9,9 @@ import (
 )
 
 func TestStaticServeHTTP(t *testing.T) {
-	a := Static{
-		MediaPath: "./tests",
-		next: HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			fmt.Fprintf(w, "OK")
-		}),
-	}
+	a := FileServeDecorator("./tests")(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "OK")
+	})
 	var (
 		req  *http.Request
 		err  error


### PR DESCRIPTION
Instead of using a structure to obtain a chain pattern using `http.HandlerFunc` and decorators

closes #23 
