### PR TITLE
Optimize the hasMatchingTag function in memory.go

### DIFF
--- a/storage/memory/memory.go
+++ b/storage/memory/memory.go
@@ -19,7 +19,6 @@ package memory
 import (
 	"log"
 	"net/url"
-	"regexp"
 	"time"
 
 	"github.com/MohawkTSDB/mohawk/storage"
@@ -335,25 +334,21 @@ func (r *Storage) checkID(tenant string, id string) {
 }
 
 func hasMatchingTag(tags map[string]string, itemTags map[string]string) bool {
-	out := true
-
-	// if no tags, all items match
 	if len(tags) == 0 {
 		return true
 	}
 
-	// if item has no tags, item is invalid
 	if len(itemTags) == 0 {
 		return false
 	}
 
-	// loop on all the tags, we need _all_ query tags to match tags on item
 	for key, value := range tags {
-		r, _ := regexp.Compile("^" + value + "$")
-		out = out && r.MatchString(itemTags[key])
+		// assuming key exists in itemTags
+		if value != itemTags[key] {
+			return false
+		}
 	}
-
-	return out
+	return true
 }
 
 func (r *Storage) maintenance() {

--- a/storage/memory/memory_test.go
+++ b/storage/memory/memory_test.go
@@ -1,0 +1,46 @@
+package memory
+
+import (
+	"testing"
+)
+
+func TestHasMatchingTag(t *testing.T) {
+	testcases := []struct {
+		tags     map[string]string
+		itemTags map[string]string
+		expected bool
+	}{
+		{
+			tags:     map[string]string{},
+			itemTags: map[string]string{"k1": "v1"},
+			expected: true,
+		},
+		{
+			tags:     map[string]string{"k1": "v1"},
+			itemTags: map[string]string{},
+			expected: false,
+		},
+		{
+			tags:     map[string]string{"k1": "v1"},
+			itemTags: map[string]string{"k1": "v1"},
+			expected: true,
+		},
+		{
+			tags:     map[string]string{"k2": "v2"},
+			itemTags: map[string]string{"k1": "v1"},
+			expected: false,
+		},
+		{
+			tags:     map[string]string{"k1": "v1"},
+			itemTags: map[string]string{"k1": "v2"},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		res := hasMatchingTag(tc.tags, tc.itemTags)
+		if res != tc.expected {
+			t.Errorf("expected hasMatchingTag to return '%v' but got '%v'", tc.expected, res)
+		}
+	}
+}


### PR DESCRIPTION
Using regexp to match the exact value in `itemTags` hurts performance. In addition, it's unnecessary because `==` does the same thing.

I added a test to verify that this change does chage the logic of `hasMatchingTag`.

To prove that mine implementation is running faster I called it `hasMatchinTag1` and ran benchmarks:
```Go
func generateTags(num int) map[string]string {
        m := map[string]string{}
        for i := 0; i < num; i++ {
                m[fmt.Sprintf("k%d", i)] = "value"
        }
        return m
}

func BenchmarkHasMatchingTag_10(b *testing.B) {
        tags := generateTags(10)
        itemTags := generateTags(10)

        for i := 0; i < b.N; i++ {
                hasMatchingTag(tags, itemTags)
        }
}

func BenchmarkHasMatchingTag1_10(b *testing.B) {
        tags := generateTags(10)
        itemTags := generateTags(10)

        for i := 0; i < b.N; i++ {
                hasMatchingTag1(tags, itemTags)
        }
}

func BenchmarkHasMatchingTag_100(b *testing.B) {
        tags := generateTags(100)
        itemTags := generateTags(100)

        for i := 0; i < b.N; i++ {
                hasMatchingTag(tags, itemTags)
        }
}

func BenchmarkHasMatchingTag1_100(b *testing.B) {
        tags := generateTags(100)
        itemTags := generateTags(100)

        for i := 0; i < b.N; i++ {
                hasMatchingTag1(tags, itemTags)
        }
}
...
```

the results were:
```shell
BenchmarkHasMatchingTag_10-4               20000             69079 ns/op           57280 B/op        580 allocs/op
BenchmarkHasMatchingTag1_10-4            3000000               475 ns/op               0 B/op          0 allocs/op
BenchmarkHasMatchingTag_100-4               2000            701758 ns/op          572813 B/op       5800 allocs/op
BenchmarkHasMatchingTag1_100-4            300000              5002 ns/op               0 B/op          0 allocs/op
BenchmarkHasMatchingTag_1000-4               200           7158635 ns/op         5729856 B/op      58020 allocs/op
BenchmarkHasMatchingTag1_1000-4            20000             68161 ns/op              18 B/op          0 allocs/op
BenchmarkHasMatchingTag_10000-4               20          96200967 ns/op        57424807 B/op     582057 allocs/op
BenchmarkHasMatchingTag1_10000-4            2000            894158 ns/op            1445 B/op         20 allocs/op
```

Signed-off-by: Boaz Shuster <ripcurld.github@gmail.com>