### PR TITLE
Handle server error in one place

### DIFF
--- a/src/apperrors/errors.go
+++ b/src/apperrors/errors.go
@@ -1,0 +1,34 @@
+package apperrors
+
+import (
+	"fmt"
+	"net/http"
+)
+
+var BadMetricIDErr = fmt.Errorf("Bad metrics ID")
+
+// Error represent an error that occured and its status code.
+type Error struct {
+	code    int
+	message string
+}
+
+func (e Error) Error() string {
+	return e.message
+}
+
+// JSON writes Error as JSON to http.ResponseWriter
+func (e Error) JSON(w http.ResponseWriter) {
+	w.WriteHeader(e.code)
+	w.Write([]byte(fmt.Sprintf(`{"code":"%d","message":"%s"}`, e.code, e.message)))
+}
+
+// BadRequest creates new Error with status code 400 from error.
+func BadRequest(err error) Error {
+	return Error{code: http.StatusBadRequest, message: err.Error()}
+}
+
+// InternalError creates new Error with status code 500 from error.
+func InternalError(err error) Error {
+	return Error{code: http.StatusInternalServerError, message: err.Error()}
+}

--- a/src/server/middleware/middleware_test.go
+++ b/src/server/middleware/middleware_test.go
@@ -12,8 +12,9 @@ func TestAppendMiddleware(t *testing.T) {
 	myRoute := router.Router{
 		Prefix: "/hawkular/bla/",
 	}
-	myRoute.Add("GET", ":id/info", func(w http.ResponseWriter, r *http.Request, argv map[string]string) {
+	myRoute.Add("GET", ":id/info", func(w http.ResponseWriter, r *http.Request, argv map[string]string) error {
 		fmt.Fprintf(w, "{\"msg\":\"got data\"")
+		return nil
 	})
 
 }

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -49,19 +49,19 @@ const publicPath = "^/hawkular/metrics/status$"
 var BackendName string
 
 // GetStatus return a json status struct
-func GetStatus(w http.ResponseWriter, r *http.Request, argv map[string]string) {
+func GetStatus(w http.ResponseWriter, r *http.Request, argv map[string]string) error {
 	resTemplate := `{"MetricsService":"STARTED","Implementation-Version":"%s","MohawkVersion":"%s","MohawkStorage":"%s"}`
 	res := fmt.Sprintf(resTemplate, defaultAPI, VER, BackendName)
 
-	w.WriteHeader(200)
 	fmt.Fprintln(w, res)
+	return nil
 }
 
 // OptionsResponse return a response for OPTIONS request
-func OptionsResponse(w http.ResponseWriter, r *http.Request, argv map[string]string) {
+func OptionsResponse(w http.ResponseWriter, r *http.Request, argv map[string]string) error {
 	w.Header().Set("Allow", "GET,PUT,POST,DELETE,OPTIONS")
 
-	w.WriteHeader(200)
+	return nil
 }
 
 func printOptionsHelp() {


### PR DESCRIPTION
This patch handles the errors from api handlers in the router. That way it is easier and more readable to handle the errors returned from the HTTP handlers.