### PR TITLE
Adding support for default tenant

### DIFF
--- a/src/cli/root.go
+++ b/src/cli/root.go
@@ -80,6 +80,7 @@ func init() {
 	RootCmd.Flags().String("alerts-server", "http://localhost:9099/append", "Alert buffer URL")
 	RootCmd.Flags().String("alerts-server-method", "POST", "Alert server http method")
 	RootCmd.Flags().Bool("alerts-server-insecure", false, "Alert server https skip verify")
+	RootCmd.Flags().String("default-tenant", "_ops", "Default tenant to use.")
 
 	// Viper Binding
 	viper.BindPFlag("storage", RootCmd.Flags().Lookup("storage"))

--- a/src/cli/root.go
+++ b/src/cli/root.go
@@ -80,7 +80,7 @@ func init() {
 	RootCmd.Flags().String("alerts-server", "http://localhost:9099/append", "Alert buffer URL")
 	RootCmd.Flags().String("alerts-server-method", "POST", "Alert server http method")
 	RootCmd.Flags().Bool("alerts-server-insecure", false, "Alert server https skip verify")
-	RootCmd.Flags().String("default-tenant", "_ops", "Default tenant to use.")
+	RootCmd.Flags().String("default-tenant", "_ops", "Default tenant to use")
 
 	// Viper Binding
 	viper.BindPFlag("storage", RootCmd.Flags().Lookup("storage"))
@@ -100,6 +100,7 @@ func init() {
 	viper.BindPFlag("alerts-server", RootCmd.Flags().Lookup("alerts-server"))
 	viper.BindPFlag("alerts-server-method", RootCmd.Flags().Lookup("alerts-server-method"))
 	viper.BindPFlag("alerts-server-insecure", RootCmd.Flags().Lookup("alerts-server"))
+	viper.BindPFlag("default-tenant", RootCmd.Flags().Lookup("default-tenant"))
 }
 
 func initConfig() {

--- a/src/server/handlers/api.go
+++ b/src/server/handlers/api.go
@@ -45,9 +45,10 @@ const secondaryOrder = "DESC"
 // 	version the version of the Hawkular server we are mocking
 // 	storage the storage to be used by the APIHhandler functions
 type APIHhandler struct {
-	Verbose bool
-	Storage storage.Storage
-	Alerts  *alerts.AlertRules
+	Verbose       bool
+	Storage       storage.Storage
+	Alerts        *alerts.AlertRules
+	DefaultTenant string
 }
 
 // GetAlertsStatus return a json alerts status struct
@@ -80,7 +81,7 @@ func (h APIHhandler) GetAlerts(w http.ResponseWriter, r *http.Request, argv map[
 	}
 
 	// get tenant
-	tenant := parseTenant(r)
+	tenant := h.parseTenant(r)
 	id := r.Form.Get("id")
 	state := r.Form.Get("state")
 
@@ -128,7 +129,7 @@ func (h APIHhandler) GetMetrics(w http.ResponseWriter, r *http.Request, argv map
 	}
 
 	// get tenant
-	tenant := parseTenant(r)
+	tenant := h.parseTenant(r)
 
 	// get a list of gauges
 	if tagsStr, ok := r.Form["tags"]; ok && len(tagsStr) > 0 {
@@ -164,7 +165,7 @@ func (h APIHhandler) GetData(w http.ResponseWriter, r *http.Request, argv map[st
 	}
 
 	// get tenant
-	tenant := parseTenant(r)
+	tenant := h.parseTenant(r)
 
 	// get timespan
 	end, start, bucketDuration, err := parseTimespan(r)
@@ -205,7 +206,7 @@ func (h APIHhandler) DeleteData(w http.ResponseWriter, r *http.Request, argv map
 	}
 
 	// get tenant
-	tenant := parseTenant(r)
+	tenant := h.parseTenant(r)
 
 	// get timespan
 	end, start, _, err := parseTimespan(r)
@@ -306,7 +307,7 @@ func (h APIHhandler) PostData(w http.ResponseWriter, r *http.Request, argv map[s
 	}
 
 	// get tenant
-	tenant := parseTenant(r)
+	tenant := h.parseTenant(r)
 
 	for _, item := range u {
 		id := item.ID
@@ -343,7 +344,7 @@ func (h APIHhandler) PutTags(w http.ResponseWriter, r *http.Request, argv map[st
 	}
 
 	// get tenant
-	tenant := parseTenant(r)
+	tenant := h.parseTenant(r)
 
 	if h.Verbose {
 		log.Printf("Tenant: %s, ID: %+v {tags: %+v}\n", tenant, id, tags)
@@ -371,7 +372,7 @@ func (h APIHhandler) PutMultiTags(w http.ResponseWriter, r *http.Request, argv m
 	}
 
 	// get tenant
-	tenant := parseTenant(r)
+	tenant := h.parseTenant(r)
 
 	for _, item := range u {
 		id := item.ID
@@ -400,7 +401,7 @@ func (h APIHhandler) DeleteTags(w http.ResponseWriter, r *http.Request, argv map
 	tags := strings.Split(tagsStr, ",")
 
 	// get tenant
-	tenant := parseTenant(r)
+	tenant := h.parseTenant(r)
 
 	if err := h.Storage.DeleteTags(tenant, id, tags); err != nil {
 		return err
@@ -413,7 +414,7 @@ func (h APIHhandler) DeleteTags(w http.ResponseWriter, r *http.Request, argv map
 // decodeRequestBody parse request body
 func (h APIHhandler) decodeRequestBody(r *http.Request) (tenant string, u dataQuery, err error) {
 	// get tenant
-	tenant = parseTenant(r)
+	tenant = h.parseTenant(r)
 
 	// decode query body
 	decoder := json.NewDecoder(r.Body)
@@ -525,4 +526,14 @@ func (h APIHhandler) getData(w http.ResponseWriter, tenant string, id string, en
 		fmt.Fprintf(w, string(resJSON))
 	}
 	return err
+}
+
+// ParseTenant return the tenant header value or the default Tenant
+func (h APIHhandler) parseTenant(r *http.Request) string {
+	tenant := r.Header.Get("Hawkular-Tenant")
+	if tenant == "" {
+		tenant = h.DefaultTenant
+	}
+
+	return tenant
 }

--- a/src/server/handlers/utils.go
+++ b/src/server/handlers/utils.go
@@ -78,16 +78,6 @@ func validTags(tags map[string]string) bool {
 	return true
 }
 
-// ParseTenant return the tenant header value or "_ops"
-func parseTenant(r *http.Request) string {
-	tenant := r.Header.Get("Hawkular-Tenant")
-	if tenant == "" {
-		tenant = "_ops"
-	}
-
-	return tenant
-}
-
 func badID(w http.ResponseWriter, v bool) {
 	w.WriteHeader(504)
 	fmt.Fprintf(w, "{\"error\":\"504\",\"message\":\"Bad metrics IDe - 504\"}")

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -89,6 +89,7 @@ func Serve() error {
 	var alertsServerURL = viper.GetString("alerts-server")
 	var alertsServerMethod = viper.GetString("alerts-server-method")
 	var alertsServerInsecure = viper.GetBool("alerts-server-insecure")
+	var defaultTenant = viper.GetString("default-tenant")
 	var configAlerts = viper.ConfigFileUsed() != "" && viper.Get("alerts") != ""
 
 	// if options is "help" print storage options help and exit
@@ -145,9 +146,10 @@ func Serve() error {
 	// h common variables to be used for the storage Handler functions
 	// Storage the storage to use for metrics source
 	h := handler.APIHhandler{
-		Verbose: verbose,
-		Storage: db,
-		Alerts:  alertRules,
+		Verbose:       verbose,
+		Storage:       db,
+		Alerts:        alertRules,
+		DefaultTenant: defaultTenant,
 	}
 
 	// Create the routers


### PR DESCRIPTION
What this does:

1. Adds a `default-tenant` flag to the mohawk cli.
2. Updates the `APIhandler` object and the api methods accordingly.
3. Extracts the `parseTenant` method from `utils` to `api`.
 
cc: @yaacov 